### PR TITLE
Enveloped signature xpath

### DIFF
--- a/src/xml/transforms/enveloped_signature.ts
+++ b/src/xml/transforms/enveloped_signature.ts
@@ -18,7 +18,7 @@ export class XmlDsigEnvelopedSignatureTransform extends Transform {
             throw new XmlError(XE.PARAM_REQUIRED, "innerXml");
         }
 
-        const signature = Select(this.innerXml, ".//*[local-name(.)='Signature' and namespace-uri(.)='http://www.w3.org/2000/09/xmldsig#']")[0];
+        const signature = Select(this.innerXml, "./*[local-name(.)='Signature' and namespace-uri(.)='http://www.w3.org/2000/09/xmldsig#']")[0];
         if (signature) {
             signature.parentNode!.removeChild(signature);
         }

--- a/test/scripts/transforms.js
+++ b/test/scripts/transforms.js
@@ -178,6 +178,17 @@ describe("Transforms", () => {
             assert.equal(new XMLSerializer().serializeToString(out), "<root/>");
         });
 
+        it("GetOutput with nested signature should leave it alone", () => {
+            let transform = new xmldsig.XmlDsigEnvelopedSignatureTransform();
+            let node = xmldsig.Parse(`<root xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion"><saml:Assertion><ds:Signature xmlns:ds="http://www.w3.org/2000/09/xmldsig#"/></saml:Assertion></root>`).documentElement;
+
+            transform.LoadInnerXml(node);
+
+            let out = transform.GetOutput();
+
+            assert.equal(new XMLSerializer().serializeToString(out), `<root xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion"><saml:Assertion><ds:Signature xmlns:ds="http://www.w3.org/2000/09/xmldsig#"/></saml:Assertion></root>`);
+        });
+
     })
 
 });


### PR DESCRIPTION
This change prevents eating up nested Signature nodes when doing double signing: one for a node inside the document, and another signature that encapsulates the document with the signed node. This is a common scenario for SAML 2.0, where the Assertion is signed first, and then the containing root node is also signed.

Fixes #37 