### PR TITLE
Sort namespacing acording to https://www.w3.org/TR/xml-c14n11/

### DIFF
--- a/src/canonicalizer.ts
+++ b/src/canonicalizer.ts
@@ -389,9 +389,13 @@ function XmlDsigC14NTransformNamespacesComparer(x: XmlCore.XmlNamespace, y: XmlC
         return -1;
     } else if (!y.prefix) {
         return 1;
+    } else if (x.prefix < y.prefix) {
+        return -1;
+    } else if (x.prefix > y.prefix) {
+        return 1;
+    } else {
+        return 0;
     }
-
-    return x.prefix.localeCompare(y.prefix);
 }
 
 function XmlDsigC14NTransformAttributesComparer(x: Node, y: Node): number {

--- a/test/canon.ts
+++ b/test/canon.ts
@@ -372,6 +372,13 @@ context("Canonicalization", () => {
       ExcC14N(xml, xpath, '<root xmlns="urn:oasis:names:tc:SAML:2.0:protocol" xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion" xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol" saml:a="1" samlp:a="1"></root>');
     });
 
+    it("#37 Canonicalization sorts upper case namespaces before lower case", () => {
+      const xml = '<root xmlns:a="urn:a.example.com" xmlns:Z="urn:z.example.com" a:a="1" Z:a="2"></root>';
+      const xpath = '//*[local-name(.)="root"]';
+      C14N(xml, xpath, '<root xmlns:Z="urn:z.example.com" xmlns:a="urn:a.example.com" a:a="1" Z:a="2"></root>');
+      ExcC14N(xml, xpath, '<root xmlns:Z="urn:z.example.com" xmlns:a="urn:a.example.com" a:a="1" Z:a="2"></root>');
+    });
+
   });
 
   // https://www.w3.org/TR/xml-c14n2-testcases/


### PR DESCRIPTION
Section 2.2 states:
  [...] An element's namespace nodes are sorted lexicographically by
  local name [...] Lexicographic comparison, which orders strings from
  least to greatest alphabetically, is based on the UCS codepoint
  values.