### PR TITLE
[xadesjs] Expose setNodeDependencies

### DIFF
--- a/packages/xades/src/index.ts
+++ b/packages/xades/src/index.ts
@@ -2,4 +2,4 @@ export * as xml from './xml/index.js';
 export * from './signed_xml.js';
 
 export { Application } from 'xmldsigjs';
-export { setNodeDependencies, Select, Parse, Convert } from 'xml-core';
+export { Select, Parse, Convert, setNodeDependencies } from 'xml-core';


### PR DESCRIPTION
Currently we nedd to explicitly refer to the `xml-core` module to get a reference to the `setNodeDependencies` function.
```bash
npm i xadesjs
```
```js
import { setNodeDependencies } from 'xml-core';
import { Application, Parse, SignedXml } from 'xadesjs';
```

This works "by mistake" because the default, not recommended strategy for npm to build dependencies is a "flat tree".

With `.npmrc`:
```properties
install-strategy=shallow
```

npm (like pnpm) install only direct deps at top-level.

This p.r. solved this and allow to configure `xml-core`:

```js
import { Application, Parse, SignedXml, setNodeDependencies } from 'xadesjs';
```

I kindly ask you to approve this improvement. Best regards.
