### PR TITLE
chore(deps): bump @xmldom/xmldom peer to ^0.9.10

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3612,13 +3612,13 @@
       }
     },
     "node_modules/@xmldom/xmldom": {
-      "version": "0.8.13",
-      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.13.tgz",
-      "integrity": "sha512-KRYzxepc14G/CEpEGc3Yn+JKaAeT63smlDr+vjB8jRfgTBBI9wRj/nkQEO+ucV8p8I9bfKLWp37uHgFrbntPvw==",
+      "version": "0.9.10",
+      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.9.10.tgz",
+      "integrity": "sha512-A9gOqLdi6cV4ibazAjcQufGj0B1y/vDqYrcuP6d/6x8P27gRS8643Dj9o1dEKtB6O7fwxb2FgBmJS2mX7gpvdw==",
       "license": "MIT",
       "peer": true,
       "engines": {
-        "node": ">=10.0.0"
+        "node": ">=14.6"
       }
     },
     "node_modules/@yarnpkg/lockfile": {
@@ -12389,7 +12389,7 @@
         "node": ">=16.0.0"
       },
       "peerDependencies": {
-        "@xmldom/xmldom": "^0.8.12",
+        "@xmldom/xmldom": "^0.9.10",
         "xpath": "^0.0.34"
       }
     },

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -60,7 +60,7 @@
     "tslib": "^2.8.1"
   },
   "peerDependencies": {
-    "@xmldom/xmldom": "^0.8.12",
+    "@xmldom/xmldom": "^0.9.10",
     "xpath": "^0.0.34"
   }
 }

--- a/packages/core/src/utils.spec.ts
+++ b/packages/core/src/utils.spec.ts
@@ -69,4 +69,9 @@ describe('utils', () => {
     const text = Stringify(xml);
     assert.equal(xmlString, text);
   });
+
+  it('Parse strips UTF-8 BOM before XML declaration', () => {
+    const xml = Parse('\uFEFF<?xml version="1.0" encoding="utf-8"?><root/>');
+    assert.equal(xml.documentElement.nodeName, 'root');
+  });
 });

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -29,7 +29,9 @@ function SelectNodesNode(node: Node, xPath: string): Node[] {
 export const Select: SelectNodes = typeof self !== 'undefined' ? SelectNodesEx : SelectNodesNode;
 
 export function Parse(xmlString: string) {
-  xmlString = xmlString.replace(/\r\n/g, '\n').replace(/\r/g, '\n');
+  // Strip UTF-8 BOM. Node's utf8 decoder preserves U+FEFF, and @xmldom/xmldom >= 0.9
+  // treats content before the XML declaration as a fatal well-formedness error.
+  xmlString = xmlString.replace(/^\uFEFF/, '').replace(/\r\n/g, '\n').replace(/\r/g, '\n');
 
   let DOMParserCtor: typeof DOMParser;
   if (typeof DOMParser !== 'undefined') {


### PR DESCRIPTION
## Summary
- Bump `xml-core` peerDependency `@xmldom/xmldom` from `^0.8.12` to `^0.9.10`, enabling consumers to use xmldom 0.9 (including [NamedNodeMap/NodeList iterators](https://github.com/xmldom/xmldom/pull/634) needed by current Vitest).
- Strip a leading UTF-8 BOM in `Parse` so documents that Node decodes with `U+FEFF` still parse under xmldom 0.9’s stricter well-formedness rules.
- Add a unit test covering BOM stripping.

Closes #103
